### PR TITLE
fix(NPE): return a string instead of a object for worldPath

### DIFF
--- a/src/main/java/ftb/utils/mod/handlers/FTBUWorldEventHandler.java
+++ b/src/main/java/ftb/utils/mod/handlers/FTBUWorldEventHandler.java
@@ -3,6 +3,7 @@ package ftb.utils.mod.handlers;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.*;
 
 import net.minecraft.entity.Entity;
@@ -33,7 +34,7 @@ public class FTBUWorldEventHandler // FTBLIntegration
 
         // Move /world/latmod/LMPlayers.txt to /world/LatMod/LMPlayers.txt
         try {
-            Path worldPath = e.world.getSaveHandler().getWorldDirectory().toPath();
+            Path worldPath = Paths.get(e.world.getSaveHandler().getWorldDirectoryName());
             Path oldFile = worldPath.resolve("latmod").resolve("LMPlayers.txt");
             Path newFile = worldPath.resolve("LatMod").resolve("LMPlayers.txt");
             if (oldFile.toFile().exists() && !newFile.toFile().exists()) {


### PR DESCRIPTION
As initially written worldPath was a file object which resulted in a NPE being thrown even though the path was being returned.

This commit makes worldPath return a string instead of an object. The NPE is no longer thrown. I believe this will still allow the code to function as intended.