### PR TITLE
fix(ServerBadges): use https instead of http

### DIFF
--- a/src/main/java/ftb/utils/badges/ServerBadges.java
+++ b/src/main/java/ftb/utils/badges/ServerBadges.java
@@ -44,7 +44,7 @@ public class ServerBadges {
             try {
                 LMURLConnection connection = new LMURLConnection(
                         RequestMethod.SIMPLE_GET,
-                        "http://pastebin.com/raw/Mu8McdDR");
+                        "https://pastebin.com/raw/Mu8McdDR");
                 global = connection.connect().asJson();
             } catch (Exception ex) {
                 ex.printStackTrace();


### PR DESCRIPTION
We need to use https instead of http to get the sample badges.json